### PR TITLE
Delete Computer

### DIFF
--- a/agileHR/templates/agileHR/computer_delete.html
+++ b/agileHR/templates/agileHR/computer_delete.html
@@ -1,0 +1,32 @@
+{% extends "agileHR/index.html" %}
+
+{% block content %}
+  <div class="row">
+    <div class="column mb-4">
+      <h1>Delete</h1>
+    </div>
+  </div>
+
+  {% if can_delete %}
+    <div class="row">
+      <div class="column">
+        <h3>Are you sure you want to delete {{ computer.make }} {{ computer.model }}?</h3>
+        <div class="my-4">
+          <form action="{% url 'agileHR:delete_computer' computer.id %}" method="POST">{% csrf_token %}<button type="submit" class="btn btn-danger">Yes, Delete it.</button>
+          <a href="{% url 'agileHR:computer_detail' computer.id %}"><button type="button" class="btn btn-primary">No, take me back.</button></a>
+        </div>
+      </div>
+    </div>
+  {% else %}
+    <div class="row">
+      <div class="column">
+        <h3>{{ computer.make }} {{ computer.model }} cannot be deleted.</h3>
+        <p>This computer is currently assigned or has been previously assigned to an employee.
+        <div class="my-4">
+          <a href="{% url 'agileHR:computer_detail' computer.id %}"><button type="button" class="btn btn-primary">Take me back.</button></a>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
+{% endblock %}

--- a/agileHR/templates/agileHR/computer_detail.html
+++ b/agileHR/templates/agileHR/computer_detail.html
@@ -17,13 +17,24 @@
         <p>{{computer.retire_date}}</p>
       {% endif %}
 
-      <h4>Assigned to:
-      {% if computer.employeecomputer_set.all %}
-        {% for rel in computer.employeecomputer_set.all %}
-          {{ rel.employee.first_name }} {{ rel.employee.last_name }}{% if not forloop.last %}, {% endif %}
+      <h4>Currently assigned to:
+      {% if current_assignment %}
+        {% for person in current_assignment %}
+          {{person.employee.first_name}} {{person.employee.last_name}}
         {% endfor %}
       {% else %}
-      Available
+        <span class="text-success">Available</span>
+      {% endif %}
+
+      {% if assignment_history %}
+      <h5>Assignment History</h5>
+        <ul>
+        {% for assignment in assignment_history %}
+          <li>{{ assignment.employee.first_name }} {{ assignment.employee.last_name }}<br>
+            {{assignment.date_assigned}} – {{assignment.date_revoked}}
+          </li>
+        {% endfor %}
+        </ul>
       {% endif %}
       </h4>
 

--- a/agileHR/templates/agileHR/computer_detail.html
+++ b/agileHR/templates/agileHR/computer_detail.html
@@ -27,6 +27,9 @@
       {% endif %}
       </h4>
 
+      <a href="{% url 'agileHR:delete_computer' computer.id %}">
+        <button class="btn btn-primary" type="button">Delete Computer</button>
+      </a>
     </div>
   </div>
 {% endblock %}

--- a/agileHR/tests/test_computer.py
+++ b/agileHR/tests/test_computer.py
@@ -97,13 +97,13 @@ class ComputerTest(TestCase):
     def test_post_new_computer(self):
         """Tests posting a new computer from the new_computer view."""
 
-        response = self.client.post(reverse('agileHR:new_computer'), {
+        response = self.client.post(reverse("agileHR:new_computer"), {
             "make": "Make",
             "model": "Model",
             "serial_no": '123456',
             "purchase_date": datetime.datetime.now()})
 
-        get_response = self.client.get(reverse('agileHR:computer_detail', args=(1,)))
+        get_response = self.client.get(reverse("agileHR:computer_detail", args=(1,)))
 
         # Getting 302 when we have a success url and the view is redirecting, but sometimes 200?
         self.assertIn(response.status_code, [302, 200])
@@ -111,3 +111,34 @@ class ComputerTest(TestCase):
         self.assertEqual(get_response.status_code, 200)
 
 
+    def test_view_delete_computer(self):
+        """Tests that the delete confirmation page loads correctly."""
+
+        response = self.client.post(reverse("agileHR:new_computer"), {
+            "make": "Make",
+            "model": "Model",
+            "serial_no": '123456',
+            "purchase_date": datetime.datetime.now()})
+
+        response = self.client.get(reverse("agileHR:delete_computer", args=(1,)))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Are you sure you want to delete".encode(), response.content)
+
+
+    def test_delete_computer(self):
+        """Tests deleting the computer from the database"""
+
+        response = self.client.post(reverse("agileHR:new_computer"), {
+            "make": "Make",
+            "model": "Model",
+            "serial_no": '123456',
+            "purchase_date": datetime.datetime.now()})
+
+        # delete the computer
+        response = self.client.post(reverse("agileHR:delete_computer", args=(1,)))
+        self.assertEqual(response.status_code, 302)
+
+        # confirm the computer is deleted
+        computer = Computer.objects.filter(pk=1)
+        self.assertEqual(len(computer), 0)

--- a/agileHR/urls.py
+++ b/agileHR/urls.py
@@ -20,6 +20,8 @@ urlpatterns = [
     path("computers/", views.computers, name="computers"),
     # ex: /bangazon/computers/12
     path("computers/<int:computer_id>/", views.computer_detail, name="computer_detail"),
+    path("computers/<int:computer_id>/delete", views.delete_computer, name="delete_computer"),
     # ex: /bangazon/computers/new
     path("computers/new/", views.new_computer, name="new_computer")
+
 ]

--- a/agileHR/views.py
+++ b/agileHR/views.py
@@ -229,9 +229,13 @@ def computer_detail(request, computer_id):
     """
 
     computer = get_object_or_404(Computer, pk=computer_id)
+    current_assignment = EmployeeComputer.objects.filter(computer_id=computer_id).filter(date_revoked=None)
+    assignment_history = EmployeeComputer.objects.filter(computer_id=computer_id).exclude(date_revoked=None).order_by('-date_assigned')
 
     context = {
-        "computer": computer
+        "computer": computer,
+        "current_assignment": current_assignment,
+        "assignment_history": assignment_history
     }
 
     return render(request, "agileHR/computer_detail.html", context)

--- a/agileHR/views.py
+++ b/agileHR/views.py
@@ -236,3 +236,34 @@ def new_computer(request):
     else:
         context = {}
         return render(request, "agileHR/computer_new.html", context)
+
+
+def delete_computer(request, computer_id):
+    """Deletes a computer ONLY if it has NEVER been assigned to an employee.
+
+        Arguments:
+            computer_id {int} -- the ID of the computer to be deleted.
+
+        Author: Sebastian Civarolo
+    """
+
+    if request.method == "POST":
+        computer = Computer.objects.get(pk=computer_id)
+        computer.delete()
+        return HttpResponseRedirect(reverse("agileHR:computers"))
+
+    else:
+        computer = Computer.objects.get(pk=computer_id)
+        assignments = EmployeeComputer.objects.filter(computer_id=computer_id)
+
+        if len(assignments) == 0:
+            context = {
+                "computer": computer,
+                "can_delete": True
+            }
+        else :
+            context = {
+                "computer": computer,
+                "can_delete": False
+            }
+        return render(request, "agileHR/computer_delete.html", context)


### PR DESCRIPTION
# Description
Covers the last part of #9. IT can delete a computer, ONLY if it has NEVER been assigned to an employee

## Related Ticket(s)
#9 

## Steps to Test Solution

1. Find a computer that says it is **Available**. Click Delete, and it will take you to a confirmation page, and then let you delete the computer. (Right now there are no available computer that have a previous history of being assigned)

2. Find a computer that is currently assigned to someone and click delete. The confirmation page should prevent you from deleting it.

## Testing

- [x] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
- [x] I certify that all existing tests pass

## Documentation
- [x] There is new documentation in this pull request that must be reviewed..
- [x] I added documentation for any new classes/methods

## Deploy Notes
No changes here.