### PR TITLE
Km edit training

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@
 - Alternatively, the user can click <em>Go Back</em> to return to the departments list without saving new data.
 
 ## Trainings
+- Training sessions can be accessed via the navbar. A list of all training sessions' titles and start date is visible.
+- Clicking <em>Add New Training</em> will open a form that prompts the user to submit a new training session title, start and end date and maximum number of attendees. Saving the session will return the user to the list of training sesssions. The user can find their training session in the list sorted by date.
+- Alternatively, the user can click <em>Go Back</em> to return to the training session list without saving new data.
+- Clicking on a training session will display the training sessions title, start and end date, maximum number of attendees, available seats as well as a list of all employees that are currently registered for that session. The user can return to the training session list by clicking <em>View all Training Sessions</em>.
+- The user can click <em>Edit Details</em> button to be taken to a form that allows the user to edit the details of the training session. Upon saving the session, the user will be returned to the updated training session detail page where their changes will be displayed.
+- Alternatively, the user can select <em>Go Back</em> to return to the training session list without saving changes.
 
 
 ## Computers

--- a/agileHR/templates/agileHR/training_detail.html
+++ b/agileHR/templates/agileHR/training_detail.html
@@ -14,7 +14,7 @@
             <div class="card-text">
                 <p>Max Attendees: {{training_details.max_attendees}} | Available Seats: {{training_details.max_attendees|sub:attendee_size}} </p>
                 <div>
-                    <a href="{% url 'agileHR:training_edit' %}"><button type="button" class="btn btn-outline-secondary">Edit Details</button></a>
+                    <a href="{% url 'agileHR:training_edit' training_details.id %}"><button type="button" class="btn btn-outline-secondary">Edit Details</button></a>
                     <a href="{% url 'agileHR:training' %}"><button type="button" class="btn btn-outline-secondary">View all Training Sessions</button></a>
                 </div>
             </div>

--- a/agileHR/templates/agileHR/training_form.html
+++ b/agileHR/templates/agileHR/training_form.html
@@ -7,7 +7,11 @@
       {{title}}
     </h2>
     <div class="card-text">
-      {% if error_message %}<p style="color:red"><strong>{{error_message}}</strong></p>{% endif %}
+      {% if error_message %}
+        <div class="alert alert-danger" role="alert">
+          {{error_message}}
+        </div>
+      {% endif %}
       {% if form_detail == "new" %}
         <form action="{% url 'agileHR:training_add' %}" method="POST">
       {% elif form_detail == "edit" %}

--- a/agileHR/templates/agileHR/training_form.html
+++ b/agileHR/templates/agileHR/training_form.html
@@ -24,7 +24,7 @@
         </div>
         <div class="form-group">
           <label for="start_date">Start Date</label>
-          <input type="date" class="form-control" name="start_date" id="start_date" value="{{training_details.start_date | date:'Y-m-d' }}"/>
+          <input type="date" class="form-control" name="start_date" value="{{training_details.start_date | date:'Y-m-d' }}"/>
         </div>
         <div class="form-group">
           <label for="end_date">End Date</label>

--- a/agileHR/templates/agileHR/training_form.html
+++ b/agileHR/templates/agileHR/training_form.html
@@ -4,27 +4,31 @@
 <div class="card mx-auto" style="width: 50 rem;">
   <div class="card-body">
     <h2 class="card-title">
-      Add New Training Session
+      {{title}}
     </h2>
     <div class="card-text">
       {% if error_message %}<p style="color:red"><strong>{{error_message}}</strong></p>{% endif %}
-      <form action="{% url 'agileHR:training_add' %}" method="POST">
+      {% if form_detail == "new" %}
+        <form action="{% url 'agileHR:training_add' %}" method="POST">
+      {% elif form_detail == "edit" %}
+        <form action="{% url 'agileHR:training_edit' training_details.id %}" method="POST">
+      {% endif %}
         {% csrf_token %}
         <div class="form-group">
           <label for="title">Title</label>
-          <input type="text" class="form-control" name="training_title"/>
+          <input type="text" class="form-control" name="training_title" value="{{training_details.title}}"/>
         </div>
         <div class="form-group">
           <label for="start_date">Start Date</label>
-          <input type="date" class="form-control" name="start_date" />
+          <input type="date" class="form-control" name="start_date" value="{{training_details.start_date | date:'Y-m-d' }}"/>
         </div>
         <div class="form-group">
           <label for="end_date">End Date</label>
-          <input type="date" class="form-control" name="end_date" />
+          <input type="date" class="form-control" name="end_date" value="{{training_details.end_date | date:'Y-m-d'}}"/>
         </div>
         <div class="form-group">
           <label for="max_attendees">Maximum Attendees</label>
-          <input type="number" class="form-control" name="max_attendees"/>
+          <input type="number" class="form-control" name="max_attendees" value="{{training_details.max_attendees}}"/>
         </div>
         <div>
           <button type="submit" class="btn btn-outline-secondary">Save</button>

--- a/agileHR/templates/agileHR/training_form.html
+++ b/agileHR/templates/agileHR/training_form.html
@@ -20,7 +20,7 @@
         </div>
         <div class="form-group">
           <label for="start_date">Start Date</label>
-          <input type="date" class="form-control" name="start_date" value="{{training_details.start_date | date:'Y-m-d' }}"/>
+          <input type="date" class="form-control" name="start_date" id="start_date" value="{{training_details.start_date | date:'Y-m-d' }}"/>
         </div>
         <div class="form-group">
           <label for="end_date">End Date</label>

--- a/agileHR/tests/test_training.py
+++ b/agileHR/tests/test_training.py
@@ -78,21 +78,21 @@ class TrainingTest(TestCase):
         # Employee first name appears in HTML response content
         self.assertIn(new_employee.first_name.encode(), response.content)
 
-    def test_display_form(self):
-        """Test case verifies that all required input fields have been correctly rendered when a form is requested"""
+    def test_display_add_form(self):
+        """Test case verifies that all required input fields have been correctly rendered when an add form is requested"""
         response = self.client.get(reverse('agileHR:training_add'))
 
         # Training title input field appears in HTML response content
-        self.assertIn('<input type="text" class="form-control" name="training_title"/>'.encode(), response.content)
+        self.assertIn('<input type="text" class="form-control" name="training_title" value=""/>'.encode(), response.content)
 
         # Training start date input field appears in HTML response content
-        self.assertIn('<input type="date" class="form-control" name="start_date" />'.encode(), response.content)
+        self.assertIn('<input type="date" class="form-control" name="start_date" value=""/>'.encode(), response.content)
 
         # Training end date input field appears in HTML response content
-        self.assertIn(' <input type="date" class="form-control" name="end_date" />'.encode(), response.content)
+        self.assertIn(' <input type="date" class="form-control" name="end_date" value=""/>'.encode(), response.content)
 
         # Training maximum attendees input field appears in HTML response content
-        self.assertIn('<input type="number" class="form-control" name="max_attendees"/>'.encode(), response.content)
+        self.assertIn('<input type="number" class="form-control" name="max_attendees" value=""/>'.encode(), response.content)
 
     def test_new_training(self):
         """Test case verifies that when a POST operation is performed to the corresponding URL, a successful response is recieved."""
@@ -104,6 +104,47 @@ class TrainingTest(TestCase):
             "end_date": future_date,
             "max_attendees": 41
         })
+
+        # Checks that the response is 200 ok
+        self.assertEqual(response.status_code, 200)
+
+    def test_display_edit_form(self):
+        """Test case verifies that all required input fields have been correctly rendered when a edit form is requested"""
+        future_date = datetime.now(tz=None)+ timedelta(days=2)
+
+        new_training = Training.objects.create(
+            title="Test Training",
+            start_date= datetime.now(tz=None),
+            end_date= future_date,
+            max_attendees= 41
+        )
+        response = self.client.get(reverse('agileHR:training_edit', args=(1,)))
+
+        # Training title input field appears in HTML response content
+        self.assertIn('<input type="text" class="form-control" name="training_title" value="Test Training"/>'.encode(), response.content)
+
+        # Training start date input field appears in HTML response content
+        self.assertIn('<input type="date" class="form-control" name="start_date" value="2019-01-30"/>'.encode(), response.content)
+
+        # Training end date input field appears in HTML response content
+        self.assertIn('<input type="date" class="form-control" name="end_date" value="2019-02-01"/>'.encode(), response.content)
+
+        # Training maximum attendees input field appears in HTML response content
+        self.assertIn('<input type="number" class="form-control" name="max_attendees" value="41"/>'.encode(), response.content)
+
+
+    def test_edit_training(self):
+        """Test case verifies that when a PUT operation is performed to the corresponding URL, a successful response is recieved"""
+        future_date = datetime.now(tz=None)+ timedelta(days=2)
+
+        new_training = Training.objects.create(
+            title="Test Training",
+            start_date= datetime.now(tz=None),
+            end_date= future_date,
+            max_attendees= 41
+        )
+
+        response = self.client.get(reverse('agileHR:training_edit', args=(1,)))
 
         # Checks that the response is 200 ok
         self.assertEqual(response.status_code, 200)

--- a/agileHR/urls.py
+++ b/agileHR/urls.py
@@ -12,8 +12,8 @@ urlpatterns = [
     path("trainings/", views.training, name="training"),
     # ex: /bangazon/trainings/5
     path("trainings/<int:training_id>", views.training_detail, name="traindetail"),
-    # ex: /bangazon/trainings/edit
-    path("trainings/edit", views.training_edit, name="training_edit"),
+    # ex: /bangazon/trainings/5/edit
+    path("trainings/<int:training_id>/edit", views.training_edit, name="training_edit"),
     # ex: /bangazon/trainings/add
     path("trainings/add", views.training_add, name="training_add"),
     # ex: /bangazon/computers/

--- a/agileHR/views.py
+++ b/agileHR/views.py
@@ -178,12 +178,21 @@ def training_edit(request, training_id):
             start_date = request.POST["start_date"]
             end_date = request.POST['end_date']
             max_attendees = request.POST['max_attendees']
-            print(type(start_date))
             if title is '' or start_date is '' or end_date is '' or max_attendees is '':
-                new_start_date = datetime.datetime.strptime(start_date, '%Y-%m-%d')
-                new_end_date = datetime.datetime.strptime(end_date, '%Y-%m-%d')
-                print(new_start_date)
-                print(type(new_start_date))
+                # If start date or end date are the fields that are left blank upon submit, repopulate the form with the data currently in the database, otherwise create a datetime object from the string passed in by the form
+                if start_date is '':
+                    new_start_date = training_details.start_date
+                    if end_date is '':
+                        new_end_date = training_details.end_date
+                    else:
+                        new_end_date = datetime.datetime.strptime(end_date, "%Y-%m-%d")
+                elif end_date is '':
+                    new_start_date = datetime.datetime.strptime(start_date, "%Y-%m-%d")
+                    new_end_date = training_details.end_date
+                else:
+                    new_start_date = datetime.datetime.strptime(start_date, "%Y-%m-%d")
+                    new_end_date = datetime.datetime.strptime(end_date, "%Y-%m-%d")
+
                 context = {
                     'error_message': "You must complete all fields in the form",
                     'title': "Edit Training Session",
@@ -193,14 +202,14 @@ def training_edit(request, training_id):
                         'title': title,
                         'start_date': new_start_date,
                         'end_date': new_end_date,
-                        'max_attendees': max_attendees}
+                        'max_attendees': max_attendees
+                    }
                 }
-                print(context)
                 return render(request, 'agileHR/training_form.html', context)
             else:
                 training_details.title = title
-                training_details.start_date = start_date
-                training_details.end_date = end_date
+                training_details.start_date = datetime.datetime.strptime(start_date, "%Y-%m-%d")
+                training_details.end_date = datetime.datetime.strptime(end_date, "%Y-%m-%d")
                 training_details.max_attendees = max_attendees
                 training_details.save()
                 return HttpResponseRedirect(reverse("agileHR:traindetail", args=(training_id,)))
@@ -211,7 +220,6 @@ def training_edit(request, training_id):
                 'form_detail': "edit", 'training_details': training_details})
     else:
         context={'training_details': training_details, 'title': "Edit Training Session" , 'form_detail': "edit" }
-        print(context)
         return render(request, 'agileHR/training_form.html', context)
 
 def training_add(request):

--- a/agileHR/views.py
+++ b/agileHR/views.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 from django.shortcuts import get_object_or_404, render
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
@@ -133,9 +133,52 @@ def training_detail(request, training_id):
     context = {'training_details': training_details, 'attendee_size': attendee_size}
     return render(request, 'agileHR/training_detail.html', context)
 
-def training_edit(request):
-    context={}
-    return render(request, 'agileHR/training_form.html', context)
+def training_edit(request, training_id):
+    training_details = get_object_or_404(Training, pk=training_id)
+    if request.method == 'POST':
+        try:
+            title = request.POST['training_title']
+            start_date = request.POST['start_date']
+            end_date = request.POST['end_date']
+            max_attendees = request.POST['max_attendees']
+            if title is '' or start_date is'' or end_date is '' or max_attendees is '':
+                if start_date is '':
+                    new_start_date = training_details.start_date,
+                else:
+                    new_start_date = datetime.strptime(start_date)
+                if end_date is '':
+                    new_end_date = training_details.end_date,
+                else:
+                    new_end_date = end_date
+                context = {
+                    'error_message': "You must complete all fields in the form",
+                    'title': "Edit Training Session",
+                    'form_detail': "edit",
+                    'training_details': {
+                        'id': training_id,
+                        'title': title,
+                        'start_date': new_start_date,
+                        'end_date': new_end_date,
+                        'max_attendees': max_attendees}
+                }
+                print(context)
+                return render(request, 'agileHR/training_form.html', context)
+            else:
+                training_details.title = title
+                training_details.start_date = start_date
+                training_details.end_date = end_date
+                training_details.max_attendees = max_attendees
+                training_details.save()
+                return HttpResponseRedirect(reverse("agileHR:traindetail", args=(training_id,)))
+        except KeyError:
+            return render(request, "agileHR/training_form.html", {
+                'error_message': "You must complete all fields in the form",
+                'title': "Edit Training Session",
+                'form_detail': "edit", 'training_details': training_details})
+    else:
+        context={'training_details': training_details, 'title': "Edit Training Session" , 'form_detail': "edit" }
+        print(context)
+        return render(request, 'agileHR/training_form.html', context)
 
 def training_add(request):
     """Displays form to add a new training session
@@ -161,7 +204,7 @@ def training_add(request):
         except KeyError:
             return render(request, 'agileHR/training_form.html', {'error_message': "You must complete all fields in the form"})
     else:
-        context={}
+        context={'title': "Add New Training Session" , 'form_detail': "new"}
         return render(request, 'agileHR/training_form.html', context)
 
 

--- a/agileHR/views.py
+++ b/agileHR/views.py
@@ -177,19 +177,15 @@ def training_edit(request, training_id):
     if request.method == 'POST':
         try:
             title = request.POST['training_title']
-            start_date = (request.POST["start_date"])
+            start_date = request.POST["start_date"]
             end_date = request.POST['end_date']
             max_attendees = request.POST['max_attendees']
-            print(start_date)
-            if title is '' or start_date is'' or end_date is '' or max_attendees is '':
-                if start_date is '':
-                    new_start_date = training_details.start_date,
-                else:
-                    new_start_date = start_date
-                if end_date is '':
-                    new_end_date = training_details.end_date,
-                else:
-                    new_end_date = end_date
+            print(type(start_date))
+            if title is '' or start_date is '' or end_date is '' or max_attendees is '':
+                new_start_date = datetime.datetime.strptime(start_date, '%Y-%m-%d')
+                new_end_date = datetime.datetime.strptime(end_date, '%Y-%m-%d')
+                print(new_start_date)
+                print(type(new_start_date))
                 context = {
                     'error_message': "You must complete all fields in the form",
                     'title': "Edit Training Session",

--- a/agileHR/views.py
+++ b/agileHR/views.py
@@ -177,14 +177,15 @@ def training_edit(request, training_id):
     if request.method == 'POST':
         try:
             title = request.POST['training_title']
-            start_date = request.POST['start_date']
+            start_date = (request.POST["start_date"])
             end_date = request.POST['end_date']
             max_attendees = request.POST['max_attendees']
+            print(start_date)
             if title is '' or start_date is'' or end_date is '' or max_attendees is '':
                 if start_date is '':
                     new_start_date = training_details.start_date,
                 else:
-                    new_start_date = datetime.strptime(start_date)
+                    new_start_date = start_date
                 if end_date is '':
                     new_end_date = training_details.end_date,
                 else:


### PR DESCRIPTION
# Description
Covers all required functionality in ticket #11 with required testing suite. 

## Related Ticket(s)
Ticket #11 

## Expected Behavior
When a user is viewing the details of a given training session, they should have an option to edit those details. When they select the edit details button, they should be taken to a form with all of the existing information pre-populated in the form. Trying to submit the form with any missing information should cause the form to be re-rendered with an error message and all unchanged date fields filled out. Once verified data has been submitted, the user should then be taken back to the training detail page, with updated information displayed. If the user selects go back at any point in the process they should be taken to a list of training sessions without their changed being saved.

When running the testing suite, 18 tests should run and pass.

## Testing

- [x] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
- [x] I certify that all existing tests pass

## Documentation
- [x] There is new documentation in this pull request that must be reviewed..
- [x] I added documentation for any new classes/methods

