### PR TITLE
SC Assign Computer

### DIFF
--- a/agileHR/models.py
+++ b/agileHR/models.py
@@ -103,9 +103,9 @@ class EmployeeTraining(models.Model):
         Returns:
             str -- Description of the employee and training relationship
      """
-    # FIXME: When deleting a training, the join table training_id is set to null. Do we want to delete the join table?
+
     employee = models.ForeignKey(Employee, on_delete=models.SET_NULL, null=True, blank=True)
-    training = models.ForeignKey(Training, on_delete=models.SET_NULL, null=True, blank=True)
+    training = models.ForeignKey(Training, on_delete=models.CASCADE, null=True, blank=True)
 
     def __str__(self):
         return f"{self.employee} is registered for {self.training}"

--- a/agileHR/templates/agileHR/computer_new.html
+++ b/agileHR/templates/agileHR/computer_new.html
@@ -33,8 +33,23 @@
               <input class="form-control" type="date" name="purchase_date" id="purchase_date" max="{% now 'Y-m-d' %}" value="{% if purchase_date %}{{ purchase_date }}{% else %}{% now 'Y-m-d' %}{% endif %}">
             </div>
           </div>
-
-          <button type="submit" class="btn btn-primary">Add Computer</button>
+          <div class="row">
+            <div class="col">
+              <label for="employee">Assign to Employee:</label>
+              <select class="form-control" name="employee" id="employee">
+                {% for employee in employees %}
+                  <option for="employee" value="{{ employee.id }}">
+                    {{employee.first_name}} {{employee.last_name}}
+                  </option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col mt-3">
+              <button type="submit" class="btn btn-primary">Add Computer</button>
+            </div>
+          </div>
         </form>
       </div>
     </div>

--- a/agileHR/templates/agileHR/computers.html
+++ b/agileHR/templates/agileHR/computers.html
@@ -14,7 +14,13 @@
         <div class="col">
             <ul>
             {% for computer in computers %}
-                <li><a href="{% url 'agileHR:computer_detail' computer.id %}">{{computer.make}} {{computer.model}}</a></li>
+                <li><a href="{% url 'agileHR:computer_detail' computer.id %}">{{computer.make}} {{computer.model}}</a>
+                {% for ec in computer.employeecomputer_set.all %}
+                    {% if not ec.date_revoked %}
+                        — {{ec.employee.first_name}} {{ec.employee.last_name}}
+                    {% endif %}
+                {% endfor %}
+                </li>
             {% endfor %}
             </ul>
         </div>

--- a/agileHR/views/computer_views.py
+++ b/agileHR/views/computer_views.py
@@ -93,10 +93,10 @@ def new_computer(request):
         computer_assignments = EmployeeComputer.objects.all()
 
         # Get employees who have had a computer but do not currently have one.
-        need_computers = Employee.objects.exclude(employeecomputer__date_revoked=None)
+        need_computers = Employee.objects.exclude(employeecomputer__date_revoked=None).order_by('last_name')
 
         # Get employees who have never had a computer.
-        never_computers = Employee.objects.exclude(employeecomputer__in=computer_assignments)
+        never_computers = Employee.objects.exclude(employeecomputer__in=computer_assignments).order_by('last_name')
 
         # Combine the two querysets
         final_list = need_computers | never_computers

--- a/agileHR/views/computer_views.py
+++ b/agileHR/views/computer_views.py
@@ -89,11 +89,16 @@ def new_computer(request):
                 "error_message": "Please fill out all fields"
             })
     else:
-        employees = Employee.objects.all()
+        # Get all computer assignment history
         computer_assignments = EmployeeComputer.objects.all()
 
+        # Get employees who have had a computer but do not currently have one.
         need_computers = Employee.objects.exclude(employeecomputer__date_revoked=None)
+
+        # Get employees who have never had a computer.
         never_computers = Employee.objects.exclude(employeecomputer__in=computer_assignments)
+
+        # Combine the two querysets
         final_list = need_computers | never_computers
 
         # print("need computers", need_computers)


### PR DESCRIPTION
# Description
Adds ability to assign a new computer to an employee who needs a computer while creating the new computer.

## Number of Fixes
Also changes the model for Training to cascade on delete.

## Related Ticket(s)
#14, #44 

## Expected Behavior
New computer should be assigned to the selected user.
Computer List should display the employee's name currently assigned to the computer.

## Steps to Test Solution

1. Create a new computer, select an employee to assign to it.
2. On the detail page, the employee should be shown, and on the Computer List, all employee names currently assigned to computers should be displayed.

## Testing

- [x] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
- [x] I certify that all existing tests pass

## Documentation
- [ ] There is new documentation in this pull request that must be reviewed..
- [ ] I added documentation for any new classes/methods

## Deploy Notes
Will require blowing up the database to use the new model for Training.
